### PR TITLE
fix(lens): remove optional types from proxy result

### DIFF
--- a/packages/lens/src/Lens.ts
+++ b/packages/lens/src/Lens.ts
@@ -60,7 +60,7 @@ export class LensS<A, S> extends Lens<A, S> {
 }
 
 export type LensSProxy<A, S> = LensS<A, S> & {
-  [K in keyof A]: LensSProxy<A[K], S>;
+  [K in keyof A]-?: LensSProxy<A[K], S>;
 };
 
 export class LensGenerator<S> {


### PR DESCRIPTION
## Description
Optional type make problem with following example.
```typescript
type Example = {
  key?: string;
};

const exampleLens = new LensGenerator<Example>().byProxy();
// TS emit an error with message `Object is possibly 'undefined'`
example.key.set()({})('abc');
```

This change will not make any problems with following case, since type parameters for `LensSProxy` will include `undefined` as a value of `key`.
```typescript
example.key.set()({ key: 'abc' })(undefined);
```