### PR TITLE
chore(package): add preversion hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,21 +5,28 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-rc.1.tgz",
-      "integrity": "sha512-qhQo3GqwqMUv03SxxjcEkWtlkEDvFYrBKbJUn4Dtd9amC2cLkJ3me4iYUVSBbVXWbfbVRalEeVBHzX4aQYKnBg==",
+      "version": "7.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-rc.3.tgz",
+      "integrity": "sha512-vH+ONMtvkQpjvKAXl5shNFyIpBwmkgKjo+buySLpQsMNDlqbJcFIMiYhwDrK4isZsae+QeHJYbqUJ0BYwyKNZw==",
       "requires": {
-        "@babel/highlight": "7.0.0-rc.1"
+        "@babel/highlight": "7.0.0-rc.3"
       }
     },
     "@babel/highlight": {
-      "version": "7.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-rc.1.tgz",
-      "integrity": "sha512-5PgPDV6F5s69XNznTcP0za3qH7qgBkr9DVQTXfZtpF+3iEyuIZB1Mjxu52F5CFxgzQUQJoBYHVxtH4Itdb5MgA==",
+      "version": "7.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-rc.3.tgz",
+      "integrity": "sha512-BwDi54dopTDbp0nIXZ1Ln7dGaZx8Vxqi8IKVFxtHHFhlTMxwVnYZlRFamRy7yOG4KEemRYhENq5ea/cNa9Jvjw==",
       "requires": {
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
-        "js-tokens": "^3.0.0"
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+        }
       }
     },
     "@commitlint/cli": {
@@ -814,9 +821,9 @@
       "integrity": "sha512-/UMY+2GkOZ27Vrc51pqC5J8SPd39FKt7kkoGAtWJ8s4msj0b15KehDWIiJpWY3/7tLxBQLLzJhIBhnEsXdzpgw=="
     },
     "@types/node": {
-      "version": "10.7.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.7.1.tgz",
-      "integrity": "sha512-EGoI4ylB/lPOaqXqtzAyL8HcgOuCtH2hkEaLmkueOYufsTFWBn4VCvlCDC2HW8Q+9iF+QVC3sxjDKQYjHQeZ9w=="
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.2.tgz",
+      "integrity": "sha512-pwZnkVyCGJ3LsQ0/3flQK5lCFao4esIzwUVzzk5NvL9vnkEyDhNf4fhHzUMHvyr56gNZywWTS2MR0euabMSz4A=="
     },
     "JSONStream": {
       "version": "1.3.3",
@@ -840,9 +847,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
-      "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ=="
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.2.tgz",
+      "integrity": "sha512-cJrKCNcr2kv8dlDnbw+JPUGjHZzo4myaxOLmpOX8a+rgX94YeTcTMv/LFJUSByRpc+i4GgVnnhLxvMu/2Y+rqw=="
     },
     "acorn-globals": {
       "version": "4.1.0",
@@ -1711,9 +1718,9 @@
       }
     },
     "compare-versions": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.3.0.tgz",
-      "integrity": "sha512-MAAAIOdi2s4Gl6rZ76PNcUa9IOYB+5ICdT41o5uMRf09aEu/F9RK+qhe8RjXNPwcTjGV7KU7h2P/fljThFVqyQ=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.3.1.tgz",
+      "integrity": "sha512-GkIcfJ9sDt4+gS+RWH3X+kR7ezuKdu3fg2oA9nRA8HZoqZwAKv3ml3TyfB9OyV2iFXxCw7q5XfV6SyPbSCT2pw=="
     },
     "component-emitter": {
       "version": "1.2.1",
@@ -2056,9 +2063,9 @@
       "integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog=="
     },
     "cssstyle": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.0.0.tgz",
-      "integrity": "sha512-Bpuh47j2mRMY60X90mXaJAEtJwxvA2roZzbgwAXYhMbmwmakdRr4Cq9L5SkleKJNLOKqHIa2YWyOXDX3VgggSQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.1.1.tgz",
+      "integrity": "sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==",
       "requires": {
         "cssom": "0.3.x"
       }
@@ -2090,19 +2097,24 @@
       }
     },
     "data-urls": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.0.tgz",
-      "integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.1.tgz",
+      "integrity": "sha512-0HdcMZzK6ubMUnsMmQmG0AcLQPvbvb47R0+7CCZQCYgcd8OUWG91CG7sM6GoXgjz+WLl4ArFzHtBMy/QqSF4eg==",
       "requires": {
-        "abab": "^1.0.4",
-        "whatwg-mimetype": "^2.0.0",
-        "whatwg-url": "^6.4.0"
+        "abab": "^2.0.0",
+        "whatwg-mimetype": "^2.1.0",
+        "whatwg-url": "^7.0.0"
       },
       "dependencies": {
-        "abab": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
-          "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
+        "whatwg-url": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+          "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
         }
       }
     },
@@ -5157,9 +5169,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "source-map-support": {
-          "version": "0.5.8",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.8.tgz",
-          "integrity": "sha512-WqAEWPdb78u25RfKzOF0swBpY0dKrNdjc4GvLwm7ScX/o9bj8Eh/YL8mcMhBHYDGl87UkkSXDOFnW4G7GhWhGg==",
+          "version": "0.5.9",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+          "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
           "requires": {
             "buffer-from": "^1.0.0",
             "source-map": "^0.6.0"
@@ -5975,9 +5987,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
+      "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
       "optional": true
     },
     "nanomatch": {
@@ -7795,12 +7807,13 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "ts-jest": {
-      "version": "23.1.3",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-23.1.3.tgz",
-      "integrity": "sha512-nb0wF7zBsmjQUmumrxiW7HQLfYdFosdZfozh+JRLgDcIjOTKe3Vpf1T9Jlp8JBi7OvZ7OFKjpXIwjL7tyliU9Q==",
+      "version": "23.1.4",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-23.1.4.tgz",
+      "integrity": "sha512-9rCSxbWfoZxxeXnSoEIzRNr9hDIQ8iEJAWmSRsWhDHDT8OeuGfURhJQUE8jtJlkyEygs6rngH8RYtHz9cfjmEA==",
       "requires": {
         "closest-file-data": "^0.1.4",
         "fs-extra": "6.0.1",
+        "json5": "^0.5.0",
         "lodash": "^4.17.10"
       }
     },

--- a/packages/applicative/package-lock.json
+++ b/packages/applicative/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@typed-f/applicative",
-	"version": "0.0.1",
+	"version": "0.3.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -186,6 +186,24 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
 			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+			"dev": true
+		},
+		"array-filter": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+			"integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
+			"dev": true
+		},
+		"array-map": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+			"integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
+			"dev": true
+		},
+		"array-reduce": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+			"integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
 			"dev": true
 		},
 		"array-unique": {
@@ -813,6 +831,12 @@
 				"delayed-stream": "~1.0.0"
 			}
 		},
+		"commander": {
+			"version": "2.17.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+			"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+			"dev": true
+		},
 		"compare-versions": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.3.0.tgz",
@@ -1038,6 +1062,12 @@
 				"webidl-conversions": "^4.0.2"
 			}
 		},
+		"duplexer": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+			"dev": true
+		},
 		"ecc-jsbn": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -1133,6 +1163,21 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
 			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
 			"dev": true
+		},
+		"event-stream": {
+			"version": "3.3.4",
+			"resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+			"dev": true,
+			"requires": {
+				"duplexer": "~0.1.1",
+				"from": "~0",
+				"map-stream": "~0.1.0",
+				"pause-stream": "0.0.11",
+				"split": "0.3",
+				"stream-combiner": "~0.0.4",
+				"through": "~2.3.1"
+			}
 		},
 		"exec-sh": {
 			"version": "0.2.2",
@@ -1481,6 +1526,12 @@
 				"map-cache": "^0.2.2"
 			}
 		},
+		"from": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+			"dev": true
+		},
 		"fs-extra": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
@@ -1518,7 +1569,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -1933,7 +1985,8 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -1989,6 +2042,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -2032,12 +2086,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -3117,6 +3173,12 @@
 			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
 			"dev": true
 		},
+		"json-parse-better-errors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"dev": true
+		},
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -3149,6 +3211,12 @@
 			"requires": {
 				"graceful-fs": "^4.1.6"
 			}
+		},
+		"jsonify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+			"dev": true
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -3301,6 +3369,12 @@
 			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
 			"dev": true
 		},
+		"map-stream": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+			"integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+			"dev": true
+		},
 		"map-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -3324,6 +3398,12 @@
 			"requires": {
 				"mimic-fn": "^1.0.0"
 			}
+		},
+		"memorystream": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+			"integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
+			"dev": true
 		},
 		"merge": {
 			"version": "1.2.0",
@@ -3519,6 +3599,12 @@
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
 		},
+		"nice-try": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+			"dev": true
+		},
 		"node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -3556,6 +3642,86 @@
 			"dev": true,
 			"requires": {
 				"remove-trailing-separator": "^1.0.1"
+			}
+		},
+		"npm-run-all": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.3.tgz",
+			"integrity": "sha512-aOG0N3Eo/WW+q6sUIdzcV2COS8VnTZCmdji0VQIAZF3b+a3YWb0AD0vFIyjKec18A7beLGbaQ5jFTNI2bPt9Cg==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^3.2.0",
+				"chalk": "^2.1.0",
+				"cross-spawn": "^6.0.4",
+				"memorystream": "^0.3.1",
+				"minimatch": "^3.0.4",
+				"ps-tree": "^1.1.0",
+				"read-pkg": "^3.0.0",
+				"shell-quote": "^1.6.1",
+				"string.prototype.padend": "^3.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
+					"requires": {
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"load-json-file": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
+					}
+				},
+				"parse-json": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"dev": true,
+					"requires": {
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
+					}
+				},
+				"path-type": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"dev": true,
+					"requires": {
+						"pify": "^3.0.0"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				},
+				"read-pkg": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+					"dev": true,
+					"requires": {
+						"load-json-file": "^4.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^3.0.0"
+					}
+				}
 			}
 		},
 		"npm-run-path": {
@@ -3819,6 +3985,15 @@
 				"pinkie-promise": "^2.0.0"
 			}
 		},
+		"pause-stream": {
+			"version": "0.0.11",
+			"resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+			"dev": true,
+			"requires": {
+				"through": "~2.3"
+			}
+		},
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -3917,6 +4092,15 @@
 			"requires": {
 				"kleur": "^2.0.1",
 				"sisteransi": "^0.1.1"
+			}
+		},
+		"ps-tree": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
+			"integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
+			"dev": true,
+			"requires": {
+				"event-stream": "~3.3.0"
 			}
 		},
 		"pseudomap": {
@@ -4333,6 +4517,18 @@
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
 			"dev": true
 		},
+		"shell-quote": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+			"integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+			"dev": true,
+			"requires": {
+				"array-filter": "~0.0.0",
+				"array-map": "~0.0.0",
+				"array-reduce": "~0.0.0",
+				"jsonify": "~0.0.0"
+			}
+		},
 		"shellwords": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
@@ -4525,6 +4721,15 @@
 			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
 			"dev": true
 		},
+		"split": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+			"integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+			"dev": true,
+			"requires": {
+				"through": "2"
+			}
+		},
 		"split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -4590,6 +4795,15 @@
 			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
 			"dev": true
 		},
+		"stream-combiner": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+			"integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+			"dev": true,
+			"requires": {
+				"duplexer": "~0.1.1"
+			}
+		},
 		"string-length": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -4608,6 +4822,17 @@
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0",
 				"strip-ansi": "^4.0.0"
+			}
+		},
+		"string.prototype.padend": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
+			"integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.4.3",
+				"function-bind": "^1.0.2"
 			}
 		},
 		"string_decoder": {
@@ -4711,6 +4936,12 @@
 			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
 			"dev": true
 		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
+		},
 		"tmpl": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -4796,6 +5027,52 @@
 				"closest-file-data": "^0.1.4",
 				"fs-extra": "6.0.1",
 				"lodash": "^4.17.10"
+			}
+		},
+		"tslib": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+			"dev": true
+		},
+		"tslint": {
+			"version": "5.11.0",
+			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
+			"integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
+			"dev": true,
+			"requires": {
+				"babel-code-frame": "^6.22.0",
+				"builtin-modules": "^1.1.1",
+				"chalk": "^2.3.0",
+				"commander": "^2.12.1",
+				"diff": "^3.2.0",
+				"glob": "^7.1.1",
+				"js-yaml": "^3.7.0",
+				"minimatch": "^3.0.4",
+				"resolve": "^1.3.2",
+				"semver": "^5.3.0",
+				"tslib": "^1.8.0",
+				"tsutils": "^2.27.2"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "1.8.1",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+					"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+					"dev": true,
+					"requires": {
+						"path-parse": "^1.0.5"
+					}
+				}
+			}
+		},
+		"tsutils": {
+			"version": "2.29.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+			"dev": true,
+			"requires": {
+				"tslib": "^1.8.1"
 			}
 		},
 		"tunnel-agent": {

--- a/packages/applicative/package.json
+++ b/packages/applicative/package.json
@@ -22,6 +22,7 @@
     "url": "git+https://github.com/Ailrun/typed-f.git"
   },
   "scripts": {
+    "preversion": "run-s clean build",
     "clean": "rimraf dist",
     "build": "tsc -p ./tsconfig.json",
     "watch": "tsc -w -p ./tsconfig.json",

--- a/packages/applicative/package.json
+++ b/packages/applicative/package.json
@@ -36,6 +36,7 @@
     "@types/jest": "^23.3.1",
     "@types/node": "^10.7.0",
     "jest": "^23.5.0",
+    "npm-run-all": "^4.1.3",
     "rimraf": "^2.6.2",
     "ts-jest": "^23.1.3",
     "tslint": "^5.11.0",

--- a/packages/either/package.json
+++ b/packages/either/package.json
@@ -23,6 +23,7 @@
     "url": "git+https://github.com/Ailrun/typed-f.git"
   },
   "scripts": {
+    "preversion": "run-s clean build",
     "clean": "rimraf dist",
     "build": "tsc -p ./tsconfig.json",
     "watch": "tsc -w -p ./tsconfig.json",

--- a/packages/function/package.json
+++ b/packages/function/package.json
@@ -22,6 +22,7 @@
     "url": "git+https://github.com/Ailrun/typed-f.git"
   },
   "scripts": {
+    "preversion": "run-s clean build",
     "clean": "rimraf dist",
     "build": "tsc -p ./tsconfig.json",
     "watch": "tsc -w -p ./tsconfig.json",

--- a/packages/functor/package-lock.json
+++ b/packages/functor/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@typed-f/functor",
-	"version": "0.0.1",
+	"version": "0.3.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -186,6 +186,24 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
 			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+			"dev": true
+		},
+		"array-filter": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+			"integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
+			"dev": true
+		},
+		"array-map": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+			"integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
+			"dev": true
+		},
+		"array-reduce": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+			"integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
 			"dev": true
 		},
 		"array-unique": {
@@ -813,6 +831,12 @@
 				"delayed-stream": "~1.0.0"
 			}
 		},
+		"commander": {
+			"version": "2.17.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+			"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+			"dev": true
+		},
 		"compare-versions": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.3.0.tgz",
@@ -1038,6 +1062,12 @@
 				"webidl-conversions": "^4.0.2"
 			}
 		},
+		"duplexer": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+			"dev": true
+		},
 		"ecc-jsbn": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -1133,6 +1163,21 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
 			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
 			"dev": true
+		},
+		"event-stream": {
+			"version": "3.3.4",
+			"resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+			"dev": true,
+			"requires": {
+				"duplexer": "~0.1.1",
+				"from": "~0",
+				"map-stream": "~0.1.0",
+				"pause-stream": "0.0.11",
+				"split": "0.3",
+				"stream-combiner": "~0.0.4",
+				"through": "~2.3.1"
+			}
 		},
 		"exec-sh": {
 			"version": "0.2.2",
@@ -1481,6 +1526,12 @@
 				"map-cache": "^0.2.2"
 			}
 		},
+		"from": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+			"dev": true
+		},
 		"fs-extra": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
@@ -1518,7 +1569,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -1933,7 +1985,8 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -1989,6 +2042,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -2032,12 +2086,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -3117,6 +3173,12 @@
 			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
 			"dev": true
 		},
+		"json-parse-better-errors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"dev": true
+		},
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -3149,6 +3211,12 @@
 			"requires": {
 				"graceful-fs": "^4.1.6"
 			}
+		},
+		"jsonify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+			"dev": true
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -3301,6 +3369,12 @@
 			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
 			"dev": true
 		},
+		"map-stream": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+			"integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+			"dev": true
+		},
 		"map-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -3324,6 +3398,12 @@
 			"requires": {
 				"mimic-fn": "^1.0.0"
 			}
+		},
+		"memorystream": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+			"integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
+			"dev": true
 		},
 		"merge": {
 			"version": "1.2.0",
@@ -3519,6 +3599,12 @@
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
 		},
+		"nice-try": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+			"dev": true
+		},
 		"node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -3556,6 +3642,86 @@
 			"dev": true,
 			"requires": {
 				"remove-trailing-separator": "^1.0.1"
+			}
+		},
+		"npm-run-all": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.3.tgz",
+			"integrity": "sha512-aOG0N3Eo/WW+q6sUIdzcV2COS8VnTZCmdji0VQIAZF3b+a3YWb0AD0vFIyjKec18A7beLGbaQ5jFTNI2bPt9Cg==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^3.2.0",
+				"chalk": "^2.1.0",
+				"cross-spawn": "^6.0.4",
+				"memorystream": "^0.3.1",
+				"minimatch": "^3.0.4",
+				"ps-tree": "^1.1.0",
+				"read-pkg": "^3.0.0",
+				"shell-quote": "^1.6.1",
+				"string.prototype.padend": "^3.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
+					"requires": {
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"load-json-file": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
+					}
+				},
+				"parse-json": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"dev": true,
+					"requires": {
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
+					}
+				},
+				"path-type": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"dev": true,
+					"requires": {
+						"pify": "^3.0.0"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				},
+				"read-pkg": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+					"dev": true,
+					"requires": {
+						"load-json-file": "^4.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^3.0.0"
+					}
+				}
 			}
 		},
 		"npm-run-path": {
@@ -3819,6 +3985,15 @@
 				"pinkie-promise": "^2.0.0"
 			}
 		},
+		"pause-stream": {
+			"version": "0.0.11",
+			"resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+			"dev": true,
+			"requires": {
+				"through": "~2.3"
+			}
+		},
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -3917,6 +4092,15 @@
 			"requires": {
 				"kleur": "^2.0.1",
 				"sisteransi": "^0.1.1"
+			}
+		},
+		"ps-tree": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
+			"integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
+			"dev": true,
+			"requires": {
+				"event-stream": "~3.3.0"
 			}
 		},
 		"pseudomap": {
@@ -4333,6 +4517,18 @@
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
 			"dev": true
 		},
+		"shell-quote": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+			"integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+			"dev": true,
+			"requires": {
+				"array-filter": "~0.0.0",
+				"array-map": "~0.0.0",
+				"array-reduce": "~0.0.0",
+				"jsonify": "~0.0.0"
+			}
+		},
 		"shellwords": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
@@ -4525,6 +4721,15 @@
 			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
 			"dev": true
 		},
+		"split": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+			"integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+			"dev": true,
+			"requires": {
+				"through": "2"
+			}
+		},
 		"split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -4590,6 +4795,15 @@
 			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
 			"dev": true
 		},
+		"stream-combiner": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+			"integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+			"dev": true,
+			"requires": {
+				"duplexer": "~0.1.1"
+			}
+		},
 		"string-length": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -4608,6 +4822,17 @@
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0",
 				"strip-ansi": "^4.0.0"
+			}
+		},
+		"string.prototype.padend": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
+			"integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.4.3",
+				"function-bind": "^1.0.2"
 			}
 		},
 		"string_decoder": {
@@ -4711,6 +4936,12 @@
 			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
 			"dev": true
 		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
+		},
 		"tmpl": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -4796,6 +5027,52 @@
 				"closest-file-data": "^0.1.4",
 				"fs-extra": "6.0.1",
 				"lodash": "^4.17.10"
+			}
+		},
+		"tslib": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+			"dev": true
+		},
+		"tslint": {
+			"version": "5.11.0",
+			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
+			"integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
+			"dev": true,
+			"requires": {
+				"babel-code-frame": "^6.22.0",
+				"builtin-modules": "^1.1.1",
+				"chalk": "^2.3.0",
+				"commander": "^2.12.1",
+				"diff": "^3.2.0",
+				"glob": "^7.1.1",
+				"js-yaml": "^3.7.0",
+				"minimatch": "^3.0.4",
+				"resolve": "^1.3.2",
+				"semver": "^5.3.0",
+				"tslib": "^1.8.0",
+				"tsutils": "^2.27.2"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "1.8.1",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+					"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+					"dev": true,
+					"requires": {
+						"path-parse": "^1.0.5"
+					}
+				}
+			}
+		},
+		"tsutils": {
+			"version": "2.29.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+			"dev": true,
+			"requires": {
+				"tslib": "^1.8.1"
 			}
 		},
 		"tunnel-agent": {

--- a/packages/functor/package.json
+++ b/packages/functor/package.json
@@ -34,6 +34,7 @@
     "@types/jest": "^23.3.1",
     "@types/node": "^10.7.0",
     "jest": "^23.5.0",
+    "npm-run-all": "^4.1.3",
     "rimraf": "^2.6.2",
     "ts-jest": "^23.1.3",
     "tslint": "^5.11.0",

--- a/packages/functor/package.json
+++ b/packages/functor/package.json
@@ -21,6 +21,7 @@
     "url": "git+https://github.com/Ailrun/typed-f.git"
   },
   "scripts": {
+    "preversion": "run-s clean build",
     "clean": "rimraf dist",
     "build": "tsc -p ./tsconfig.json",
     "watch": "tsc -w -p ./tsconfig.json",

--- a/packages/lens/package-lock.json
+++ b/packages/lens/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@typed-f/lens",
-	"version": "0.0.1",
+	"version": "0.3.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -186,6 +186,24 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
 			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+			"dev": true
+		},
+		"array-filter": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+			"integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
+			"dev": true
+		},
+		"array-map": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+			"integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
+			"dev": true
+		},
+		"array-reduce": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+			"integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
 			"dev": true
 		},
 		"array-unique": {
@@ -813,6 +831,12 @@
 				"delayed-stream": "~1.0.0"
 			}
 		},
+		"commander": {
+			"version": "2.17.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+			"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+			"dev": true
+		},
 		"compare-versions": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.3.0.tgz",
@@ -1038,6 +1062,12 @@
 				"webidl-conversions": "^4.0.2"
 			}
 		},
+		"duplexer": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+			"dev": true
+		},
 		"ecc-jsbn": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -1133,6 +1163,21 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
 			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
 			"dev": true
+		},
+		"event-stream": {
+			"version": "3.3.4",
+			"resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+			"dev": true,
+			"requires": {
+				"duplexer": "~0.1.1",
+				"from": "~0",
+				"map-stream": "~0.1.0",
+				"pause-stream": "0.0.11",
+				"split": "0.3",
+				"stream-combiner": "~0.0.4",
+				"through": "~2.3.1"
+			}
 		},
 		"exec-sh": {
 			"version": "0.2.2",
@@ -1481,6 +1526,12 @@
 				"map-cache": "^0.2.2"
 			}
 		},
+		"from": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+			"dev": true
+		},
 		"fs-extra": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
@@ -1518,7 +1569,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -1933,7 +1985,8 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -1989,6 +2042,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -2032,12 +2086,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -3117,6 +3173,12 @@
 			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
 			"dev": true
 		},
+		"json-parse-better-errors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"dev": true
+		},
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -3149,6 +3211,12 @@
 			"requires": {
 				"graceful-fs": "^4.1.6"
 			}
+		},
+		"jsonify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+			"dev": true
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -3301,6 +3369,12 @@
 			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
 			"dev": true
 		},
+		"map-stream": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+			"integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+			"dev": true
+		},
 		"map-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -3324,6 +3398,12 @@
 			"requires": {
 				"mimic-fn": "^1.0.0"
 			}
+		},
+		"memorystream": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+			"integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
+			"dev": true
 		},
 		"merge": {
 			"version": "1.2.0",
@@ -3519,6 +3599,12 @@
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
 		},
+		"nice-try": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+			"dev": true
+		},
 		"node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -3556,6 +3642,86 @@
 			"dev": true,
 			"requires": {
 				"remove-trailing-separator": "^1.0.1"
+			}
+		},
+		"npm-run-all": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.3.tgz",
+			"integrity": "sha512-aOG0N3Eo/WW+q6sUIdzcV2COS8VnTZCmdji0VQIAZF3b+a3YWb0AD0vFIyjKec18A7beLGbaQ5jFTNI2bPt9Cg==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^3.2.0",
+				"chalk": "^2.1.0",
+				"cross-spawn": "^6.0.4",
+				"memorystream": "^0.3.1",
+				"minimatch": "^3.0.4",
+				"ps-tree": "^1.1.0",
+				"read-pkg": "^3.0.0",
+				"shell-quote": "^1.6.1",
+				"string.prototype.padend": "^3.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
+					"requires": {
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"load-json-file": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
+					}
+				},
+				"parse-json": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"dev": true,
+					"requires": {
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
+					}
+				},
+				"path-type": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"dev": true,
+					"requires": {
+						"pify": "^3.0.0"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				},
+				"read-pkg": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+					"dev": true,
+					"requires": {
+						"load-json-file": "^4.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^3.0.0"
+					}
+				}
 			}
 		},
 		"npm-run-path": {
@@ -3819,6 +3985,15 @@
 				"pinkie-promise": "^2.0.0"
 			}
 		},
+		"pause-stream": {
+			"version": "0.0.11",
+			"resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+			"dev": true,
+			"requires": {
+				"through": "~2.3"
+			}
+		},
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -3917,6 +4092,15 @@
 			"requires": {
 				"kleur": "^2.0.1",
 				"sisteransi": "^0.1.1"
+			}
+		},
+		"ps-tree": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
+			"integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
+			"dev": true,
+			"requires": {
+				"event-stream": "~3.3.0"
 			}
 		},
 		"pseudomap": {
@@ -4333,6 +4517,18 @@
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
 			"dev": true
 		},
+		"shell-quote": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+			"integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+			"dev": true,
+			"requires": {
+				"array-filter": "~0.0.0",
+				"array-map": "~0.0.0",
+				"array-reduce": "~0.0.0",
+				"jsonify": "~0.0.0"
+			}
+		},
 		"shellwords": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
@@ -4525,6 +4721,15 @@
 			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
 			"dev": true
 		},
+		"split": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+			"integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+			"dev": true,
+			"requires": {
+				"through": "2"
+			}
+		},
 		"split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -4590,6 +4795,15 @@
 			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
 			"dev": true
 		},
+		"stream-combiner": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+			"integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+			"dev": true,
+			"requires": {
+				"duplexer": "~0.1.1"
+			}
+		},
 		"string-length": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -4608,6 +4822,17 @@
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0",
 				"strip-ansi": "^4.0.0"
+			}
+		},
+		"string.prototype.padend": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
+			"integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.4.3",
+				"function-bind": "^1.0.2"
 			}
 		},
 		"string_decoder": {
@@ -4711,6 +4936,12 @@
 			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
 			"dev": true
 		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
+		},
 		"tmpl": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -4796,6 +5027,52 @@
 				"closest-file-data": "^0.1.4",
 				"fs-extra": "6.0.1",
 				"lodash": "^4.17.10"
+			}
+		},
+		"tslib": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+			"dev": true
+		},
+		"tslint": {
+			"version": "5.11.0",
+			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
+			"integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
+			"dev": true,
+			"requires": {
+				"babel-code-frame": "^6.22.0",
+				"builtin-modules": "^1.1.1",
+				"chalk": "^2.3.0",
+				"commander": "^2.12.1",
+				"diff": "^3.2.0",
+				"glob": "^7.1.1",
+				"js-yaml": "^3.7.0",
+				"minimatch": "^3.0.4",
+				"resolve": "^1.3.2",
+				"semver": "^5.3.0",
+				"tslib": "^1.8.0",
+				"tsutils": "^2.27.2"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "1.8.1",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+					"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+					"dev": true,
+					"requires": {
+						"path-parse": "^1.0.5"
+					}
+				}
+			}
+		},
+		"tsutils": {
+			"version": "2.29.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+			"dev": true,
+			"requires": {
+				"tslib": "^1.8.1"
 			}
 		},
 		"tunnel-agent": {

--- a/packages/lens/package.json
+++ b/packages/lens/package.json
@@ -33,6 +33,7 @@
     "@types/jest": "^23.3.1",
     "@types/node": "^10.7.0",
     "jest": "^23.5.0",
+    "npm-run-all": "^4.1.3",
     "rimraf": "^2.6.2",
     "ts-jest": "^23.1.3",
     "tslint": "^5.11.0",

--- a/packages/lens/package.json
+++ b/packages/lens/package.json
@@ -21,6 +21,7 @@
     "url": "git+https://github.com/Ailrun/typed-f.git"
   },
   "scripts": {
+    "preversion": "run-s clean build",
     "clean": "rimraf dist",
     "build": "tsc -p ./tsconfig.json",
     "watch": "tsc -w -p ./tsconfig.json",

--- a/packages/matchable/package-lock.json
+++ b/packages/matchable/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@typed-f/matchable",
-	"version": "0.0.1",
+	"version": "0.3.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -186,6 +186,24 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
 			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+			"dev": true
+		},
+		"array-filter": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+			"integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
+			"dev": true
+		},
+		"array-map": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+			"integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
+			"dev": true
+		},
+		"array-reduce": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+			"integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
 			"dev": true
 		},
 		"array-unique": {
@@ -813,6 +831,12 @@
 				"delayed-stream": "~1.0.0"
 			}
 		},
+		"commander": {
+			"version": "2.17.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+			"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+			"dev": true
+		},
 		"compare-versions": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.3.0.tgz",
@@ -1038,6 +1062,12 @@
 				"webidl-conversions": "^4.0.2"
 			}
 		},
+		"duplexer": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+			"dev": true
+		},
 		"ecc-jsbn": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -1133,6 +1163,21 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
 			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
 			"dev": true
+		},
+		"event-stream": {
+			"version": "3.3.4",
+			"resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+			"dev": true,
+			"requires": {
+				"duplexer": "~0.1.1",
+				"from": "~0",
+				"map-stream": "~0.1.0",
+				"pause-stream": "0.0.11",
+				"split": "0.3",
+				"stream-combiner": "~0.0.4",
+				"through": "~2.3.1"
+			}
 		},
 		"exec-sh": {
 			"version": "0.2.2",
@@ -1481,6 +1526,12 @@
 				"map-cache": "^0.2.2"
 			}
 		},
+		"from": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+			"dev": true
+		},
 		"fs-extra": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
@@ -1518,7 +1569,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -1933,7 +1985,8 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -1989,6 +2042,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -2032,12 +2086,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -3117,6 +3173,12 @@
 			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
 			"dev": true
 		},
+		"json-parse-better-errors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"dev": true
+		},
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -3149,6 +3211,12 @@
 			"requires": {
 				"graceful-fs": "^4.1.6"
 			}
+		},
+		"jsonify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+			"dev": true
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -3301,6 +3369,12 @@
 			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
 			"dev": true
 		},
+		"map-stream": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+			"integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+			"dev": true
+		},
 		"map-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -3324,6 +3398,12 @@
 			"requires": {
 				"mimic-fn": "^1.0.0"
 			}
+		},
+		"memorystream": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+			"integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
+			"dev": true
 		},
 		"merge": {
 			"version": "1.2.0",
@@ -3519,6 +3599,12 @@
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
 		},
+		"nice-try": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+			"dev": true
+		},
 		"node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -3556,6 +3642,86 @@
 			"dev": true,
 			"requires": {
 				"remove-trailing-separator": "^1.0.1"
+			}
+		},
+		"npm-run-all": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.3.tgz",
+			"integrity": "sha512-aOG0N3Eo/WW+q6sUIdzcV2COS8VnTZCmdji0VQIAZF3b+a3YWb0AD0vFIyjKec18A7beLGbaQ5jFTNI2bPt9Cg==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^3.2.0",
+				"chalk": "^2.1.0",
+				"cross-spawn": "^6.0.4",
+				"memorystream": "^0.3.1",
+				"minimatch": "^3.0.4",
+				"ps-tree": "^1.1.0",
+				"read-pkg": "^3.0.0",
+				"shell-quote": "^1.6.1",
+				"string.prototype.padend": "^3.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
+					"requires": {
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"load-json-file": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
+					}
+				},
+				"parse-json": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"dev": true,
+					"requires": {
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
+					}
+				},
+				"path-type": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"dev": true,
+					"requires": {
+						"pify": "^3.0.0"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				},
+				"read-pkg": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+					"dev": true,
+					"requires": {
+						"load-json-file": "^4.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^3.0.0"
+					}
+				}
 			}
 		},
 		"npm-run-path": {
@@ -3819,6 +3985,15 @@
 				"pinkie-promise": "^2.0.0"
 			}
 		},
+		"pause-stream": {
+			"version": "0.0.11",
+			"resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+			"dev": true,
+			"requires": {
+				"through": "~2.3"
+			}
+		},
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -3917,6 +4092,15 @@
 			"requires": {
 				"kleur": "^2.0.1",
 				"sisteransi": "^0.1.1"
+			}
+		},
+		"ps-tree": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
+			"integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
+			"dev": true,
+			"requires": {
+				"event-stream": "~3.3.0"
 			}
 		},
 		"pseudomap": {
@@ -4333,6 +4517,18 @@
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
 			"dev": true
 		},
+		"shell-quote": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+			"integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+			"dev": true,
+			"requires": {
+				"array-filter": "~0.0.0",
+				"array-map": "~0.0.0",
+				"array-reduce": "~0.0.0",
+				"jsonify": "~0.0.0"
+			}
+		},
 		"shellwords": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
@@ -4525,6 +4721,15 @@
 			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
 			"dev": true
 		},
+		"split": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+			"integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+			"dev": true,
+			"requires": {
+				"through": "2"
+			}
+		},
 		"split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -4590,6 +4795,15 @@
 			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
 			"dev": true
 		},
+		"stream-combiner": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+			"integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+			"dev": true,
+			"requires": {
+				"duplexer": "~0.1.1"
+			}
+		},
 		"string-length": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -4608,6 +4822,17 @@
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0",
 				"strip-ansi": "^4.0.0"
+			}
+		},
+		"string.prototype.padend": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
+			"integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.4.3",
+				"function-bind": "^1.0.2"
 			}
 		},
 		"string_decoder": {
@@ -4711,6 +4936,12 @@
 			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
 			"dev": true
 		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
+		},
 		"tmpl": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -4796,6 +5027,52 @@
 				"closest-file-data": "^0.1.4",
 				"fs-extra": "6.0.1",
 				"lodash": "^4.17.10"
+			}
+		},
+		"tslib": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+			"dev": true
+		},
+		"tslint": {
+			"version": "5.11.0",
+			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
+			"integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
+			"dev": true,
+			"requires": {
+				"babel-code-frame": "^6.22.0",
+				"builtin-modules": "^1.1.1",
+				"chalk": "^2.3.0",
+				"commander": "^2.12.1",
+				"diff": "^3.2.0",
+				"glob": "^7.1.1",
+				"js-yaml": "^3.7.0",
+				"minimatch": "^3.0.4",
+				"resolve": "^1.3.2",
+				"semver": "^5.3.0",
+				"tslib": "^1.8.0",
+				"tsutils": "^2.27.2"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "1.8.1",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+					"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+					"dev": true,
+					"requires": {
+						"path-parse": "^1.0.5"
+					}
+				}
+			}
+		},
+		"tsutils": {
+			"version": "2.29.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+			"dev": true,
+			"requires": {
+				"tslib": "^1.8.1"
 			}
 		},
 		"tunnel-agent": {

--- a/packages/matchable/package.json
+++ b/packages/matchable/package.json
@@ -33,6 +33,7 @@
     "@types/jest": "^23.3.1",
     "@types/node": "^10.7.0",
     "jest": "^23.5.0",
+    "npm-run-all": "^4.1.3",
     "rimraf": "^2.6.2",
     "ts-jest": "^23.1.3",
     "tslint": "^5.11.0",

--- a/packages/matchable/package.json
+++ b/packages/matchable/package.json
@@ -21,6 +21,7 @@
     "url": "git+https://github.com/Ailrun/typed-f.git"
   },
   "scripts": {
+    "preversion": "run-s clean build",
     "clean": "rimraf dist",
     "build": "tsc -p ./tsconfig.json",
     "watch": "tsc -w -p ./tsconfig.json",

--- a/packages/maybe/package.json
+++ b/packages/maybe/package.json
@@ -23,6 +23,7 @@
     "url": "git+https://github.com/Ailrun/typed-f.git"
   },
   "scripts": {
+    "preversion": "run-s clean build",
     "clean": "rimraf dist",
     "build": "tsc -p ./tsconfig.json",
     "watch": "tsc -w -p ./tsconfig.json",

--- a/packages/monad/package-lock.json
+++ b/packages/monad/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@typed-f/monad",
-	"version": "0.0.1",
+	"version": "0.3.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -186,6 +186,24 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
 			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+			"dev": true
+		},
+		"array-filter": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+			"integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
+			"dev": true
+		},
+		"array-map": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+			"integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
+			"dev": true
+		},
+		"array-reduce": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+			"integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
 			"dev": true
 		},
 		"array-unique": {
@@ -813,6 +831,12 @@
 				"delayed-stream": "~1.0.0"
 			}
 		},
+		"commander": {
+			"version": "2.17.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+			"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+			"dev": true
+		},
 		"compare-versions": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.3.0.tgz",
@@ -1038,6 +1062,12 @@
 				"webidl-conversions": "^4.0.2"
 			}
 		},
+		"duplexer": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+			"dev": true
+		},
 		"ecc-jsbn": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -1133,6 +1163,21 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
 			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
 			"dev": true
+		},
+		"event-stream": {
+			"version": "3.3.4",
+			"resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+			"dev": true,
+			"requires": {
+				"duplexer": "~0.1.1",
+				"from": "~0",
+				"map-stream": "~0.1.0",
+				"pause-stream": "0.0.11",
+				"split": "0.3",
+				"stream-combiner": "~0.0.4",
+				"through": "~2.3.1"
+			}
 		},
 		"exec-sh": {
 			"version": "0.2.2",
@@ -1481,6 +1526,12 @@
 				"map-cache": "^0.2.2"
 			}
 		},
+		"from": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+			"dev": true
+		},
 		"fs-extra": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
@@ -1518,7 +1569,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -1933,7 +1985,8 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -1989,6 +2042,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -2032,12 +2086,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -3117,6 +3173,12 @@
 			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
 			"dev": true
 		},
+		"json-parse-better-errors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"dev": true
+		},
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -3149,6 +3211,12 @@
 			"requires": {
 				"graceful-fs": "^4.1.6"
 			}
+		},
+		"jsonify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+			"dev": true
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -3301,6 +3369,12 @@
 			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
 			"dev": true
 		},
+		"map-stream": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+			"integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+			"dev": true
+		},
 		"map-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -3324,6 +3398,12 @@
 			"requires": {
 				"mimic-fn": "^1.0.0"
 			}
+		},
+		"memorystream": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+			"integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
+			"dev": true
 		},
 		"merge": {
 			"version": "1.2.0",
@@ -3519,6 +3599,12 @@
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
 		},
+		"nice-try": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+			"dev": true
+		},
 		"node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -3556,6 +3642,86 @@
 			"dev": true,
 			"requires": {
 				"remove-trailing-separator": "^1.0.1"
+			}
+		},
+		"npm-run-all": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.3.tgz",
+			"integrity": "sha512-aOG0N3Eo/WW+q6sUIdzcV2COS8VnTZCmdji0VQIAZF3b+a3YWb0AD0vFIyjKec18A7beLGbaQ5jFTNI2bPt9Cg==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^3.2.0",
+				"chalk": "^2.1.0",
+				"cross-spawn": "^6.0.4",
+				"memorystream": "^0.3.1",
+				"minimatch": "^3.0.4",
+				"ps-tree": "^1.1.0",
+				"read-pkg": "^3.0.0",
+				"shell-quote": "^1.6.1",
+				"string.prototype.padend": "^3.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
+					"requires": {
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"load-json-file": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
+					}
+				},
+				"parse-json": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"dev": true,
+					"requires": {
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
+					}
+				},
+				"path-type": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"dev": true,
+					"requires": {
+						"pify": "^3.0.0"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				},
+				"read-pkg": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+					"dev": true,
+					"requires": {
+						"load-json-file": "^4.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^3.0.0"
+					}
+				}
 			}
 		},
 		"npm-run-path": {
@@ -3819,6 +3985,15 @@
 				"pinkie-promise": "^2.0.0"
 			}
 		},
+		"pause-stream": {
+			"version": "0.0.11",
+			"resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+			"dev": true,
+			"requires": {
+				"through": "~2.3"
+			}
+		},
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -3917,6 +4092,15 @@
 			"requires": {
 				"kleur": "^2.0.1",
 				"sisteransi": "^0.1.1"
+			}
+		},
+		"ps-tree": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
+			"integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
+			"dev": true,
+			"requires": {
+				"event-stream": "~3.3.0"
 			}
 		},
 		"pseudomap": {
@@ -4333,6 +4517,18 @@
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
 			"dev": true
 		},
+		"shell-quote": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+			"integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+			"dev": true,
+			"requires": {
+				"array-filter": "~0.0.0",
+				"array-map": "~0.0.0",
+				"array-reduce": "~0.0.0",
+				"jsonify": "~0.0.0"
+			}
+		},
 		"shellwords": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
@@ -4525,6 +4721,15 @@
 			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
 			"dev": true
 		},
+		"split": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+			"integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+			"dev": true,
+			"requires": {
+				"through": "2"
+			}
+		},
 		"split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -4590,6 +4795,15 @@
 			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
 			"dev": true
 		},
+		"stream-combiner": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+			"integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+			"dev": true,
+			"requires": {
+				"duplexer": "~0.1.1"
+			}
+		},
 		"string-length": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -4608,6 +4822,17 @@
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0",
 				"strip-ansi": "^4.0.0"
+			}
+		},
+		"string.prototype.padend": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
+			"integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.4.3",
+				"function-bind": "^1.0.2"
 			}
 		},
 		"string_decoder": {
@@ -4711,6 +4936,12 @@
 			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
 			"dev": true
 		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
+		},
 		"tmpl": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -4796,6 +5027,52 @@
 				"closest-file-data": "^0.1.4",
 				"fs-extra": "6.0.1",
 				"lodash": "^4.17.10"
+			}
+		},
+		"tslib": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+			"dev": true
+		},
+		"tslint": {
+			"version": "5.11.0",
+			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
+			"integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
+			"dev": true,
+			"requires": {
+				"babel-code-frame": "^6.22.0",
+				"builtin-modules": "^1.1.1",
+				"chalk": "^2.3.0",
+				"commander": "^2.12.1",
+				"diff": "^3.2.0",
+				"glob": "^7.1.1",
+				"js-yaml": "^3.7.0",
+				"minimatch": "^3.0.4",
+				"resolve": "^1.3.2",
+				"semver": "^5.3.0",
+				"tslib": "^1.8.0",
+				"tsutils": "^2.27.2"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "1.8.1",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+					"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+					"dev": true,
+					"requires": {
+						"path-parse": "^1.0.5"
+					}
+				}
+			}
+		},
+		"tsutils": {
+			"version": "2.29.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+			"dev": true,
+			"requires": {
+				"tslib": "^1.8.1"
 			}
 		},
 		"tunnel-agent": {

--- a/packages/monad/package.json
+++ b/packages/monad/package.json
@@ -37,6 +37,7 @@
     "@types/jest": "^23.3.1",
     "@types/node": "^10.7.0",
     "jest": "^23.5.0",
+    "npm-run-all": "^4.1.3",
     "rimraf": "^2.6.2",
     "ts-jest": "^23.1.3",
     "tslint": "^5.11.0",

--- a/packages/monad/package.json
+++ b/packages/monad/package.json
@@ -23,6 +23,7 @@
     "url": "git+https://github.com/Ailrun/typed-f.git"
   },
   "scripts": {
+    "preversion": "run-s clean build",
     "clean": "rimraf dist",
     "build": "tsc -p ./tsconfig.json",
     "watch": "tsc -w -p ./tsconfig.json",

--- a/packages/setoid/package-lock.json
+++ b/packages/setoid/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@typed-f/setoid",
-	"version": "0.0.1",
+	"version": "0.3.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -186,6 +186,24 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
 			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+			"dev": true
+		},
+		"array-filter": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+			"integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
+			"dev": true
+		},
+		"array-map": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+			"integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
+			"dev": true
+		},
+		"array-reduce": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+			"integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
 			"dev": true
 		},
 		"array-unique": {
@@ -813,6 +831,12 @@
 				"delayed-stream": "~1.0.0"
 			}
 		},
+		"commander": {
+			"version": "2.17.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+			"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+			"dev": true
+		},
 		"compare-versions": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.3.0.tgz",
@@ -1038,6 +1062,12 @@
 				"webidl-conversions": "^4.0.2"
 			}
 		},
+		"duplexer": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+			"dev": true
+		},
 		"ecc-jsbn": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -1133,6 +1163,21 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
 			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
 			"dev": true
+		},
+		"event-stream": {
+			"version": "3.3.4",
+			"resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+			"dev": true,
+			"requires": {
+				"duplexer": "~0.1.1",
+				"from": "~0",
+				"map-stream": "~0.1.0",
+				"pause-stream": "0.0.11",
+				"split": "0.3",
+				"stream-combiner": "~0.0.4",
+				"through": "~2.3.1"
+			}
 		},
 		"exec-sh": {
 			"version": "0.2.2",
@@ -1481,6 +1526,12 @@
 				"map-cache": "^0.2.2"
 			}
 		},
+		"from": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+			"dev": true
+		},
 		"fs-extra": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
@@ -1518,7 +1569,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -1933,7 +1985,8 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -1989,6 +2042,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -2032,12 +2086,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -3117,6 +3173,12 @@
 			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
 			"dev": true
 		},
+		"json-parse-better-errors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"dev": true
+		},
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -3149,6 +3211,12 @@
 			"requires": {
 				"graceful-fs": "^4.1.6"
 			}
+		},
+		"jsonify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+			"dev": true
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -3301,6 +3369,12 @@
 			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
 			"dev": true
 		},
+		"map-stream": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+			"integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+			"dev": true
+		},
 		"map-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -3324,6 +3398,12 @@
 			"requires": {
 				"mimic-fn": "^1.0.0"
 			}
+		},
+		"memorystream": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+			"integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
+			"dev": true
 		},
 		"merge": {
 			"version": "1.2.0",
@@ -3519,6 +3599,12 @@
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
 		},
+		"nice-try": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+			"dev": true
+		},
 		"node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -3556,6 +3642,86 @@
 			"dev": true,
 			"requires": {
 				"remove-trailing-separator": "^1.0.1"
+			}
+		},
+		"npm-run-all": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.3.tgz",
+			"integrity": "sha512-aOG0N3Eo/WW+q6sUIdzcV2COS8VnTZCmdji0VQIAZF3b+a3YWb0AD0vFIyjKec18A7beLGbaQ5jFTNI2bPt9Cg==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^3.2.0",
+				"chalk": "^2.1.0",
+				"cross-spawn": "^6.0.4",
+				"memorystream": "^0.3.1",
+				"minimatch": "^3.0.4",
+				"ps-tree": "^1.1.0",
+				"read-pkg": "^3.0.0",
+				"shell-quote": "^1.6.1",
+				"string.prototype.padend": "^3.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
+					"requires": {
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"load-json-file": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
+					}
+				},
+				"parse-json": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"dev": true,
+					"requires": {
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
+					}
+				},
+				"path-type": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"dev": true,
+					"requires": {
+						"pify": "^3.0.0"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				},
+				"read-pkg": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+					"dev": true,
+					"requires": {
+						"load-json-file": "^4.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^3.0.0"
+					}
+				}
 			}
 		},
 		"npm-run-path": {
@@ -3819,6 +3985,15 @@
 				"pinkie-promise": "^2.0.0"
 			}
 		},
+		"pause-stream": {
+			"version": "0.0.11",
+			"resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+			"dev": true,
+			"requires": {
+				"through": "~2.3"
+			}
+		},
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -3917,6 +4092,15 @@
 			"requires": {
 				"kleur": "^2.0.1",
 				"sisteransi": "^0.1.1"
+			}
+		},
+		"ps-tree": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
+			"integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
+			"dev": true,
+			"requires": {
+				"event-stream": "~3.3.0"
 			}
 		},
 		"pseudomap": {
@@ -4333,6 +4517,18 @@
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
 			"dev": true
 		},
+		"shell-quote": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+			"integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+			"dev": true,
+			"requires": {
+				"array-filter": "~0.0.0",
+				"array-map": "~0.0.0",
+				"array-reduce": "~0.0.0",
+				"jsonify": "~0.0.0"
+			}
+		},
 		"shellwords": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
@@ -4525,6 +4721,15 @@
 			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
 			"dev": true
 		},
+		"split": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+			"integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+			"dev": true,
+			"requires": {
+				"through": "2"
+			}
+		},
 		"split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -4590,6 +4795,15 @@
 			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
 			"dev": true
 		},
+		"stream-combiner": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+			"integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+			"dev": true,
+			"requires": {
+				"duplexer": "~0.1.1"
+			}
+		},
 		"string-length": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -4608,6 +4822,17 @@
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0",
 				"strip-ansi": "^4.0.0"
+			}
+		},
+		"string.prototype.padend": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
+			"integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.4.3",
+				"function-bind": "^1.0.2"
 			}
 		},
 		"string_decoder": {
@@ -4711,6 +4936,12 @@
 			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
 			"dev": true
 		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
+		},
 		"tmpl": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -4796,6 +5027,52 @@
 				"closest-file-data": "^0.1.4",
 				"fs-extra": "6.0.1",
 				"lodash": "^4.17.10"
+			}
+		},
+		"tslib": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+			"dev": true
+		},
+		"tslint": {
+			"version": "5.11.0",
+			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
+			"integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
+			"dev": true,
+			"requires": {
+				"babel-code-frame": "^6.22.0",
+				"builtin-modules": "^1.1.1",
+				"chalk": "^2.3.0",
+				"commander": "^2.12.1",
+				"diff": "^3.2.0",
+				"glob": "^7.1.1",
+				"js-yaml": "^3.7.0",
+				"minimatch": "^3.0.4",
+				"resolve": "^1.3.2",
+				"semver": "^5.3.0",
+				"tslib": "^1.8.0",
+				"tsutils": "^2.27.2"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "1.8.1",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+					"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+					"dev": true,
+					"requires": {
+						"path-parse": "^1.0.5"
+					}
+				}
+			}
+		},
+		"tsutils": {
+			"version": "2.29.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+			"dev": true,
+			"requires": {
+				"tslib": "^1.8.1"
 			}
 		},
 		"tunnel-agent": {

--- a/packages/setoid/package.json
+++ b/packages/setoid/package.json
@@ -22,6 +22,7 @@
     "url": "git+https://github.com/Ailrun/typed-f.git"
   },
   "scripts": {
+    "preversion": "run-s clean build",
     "clean": "rimraf dist",
     "build": "tsc -p ./tsconfig.json",
     "watch": "tsc -w -p ./tsconfig.json",

--- a/packages/setoid/package.json
+++ b/packages/setoid/package.json
@@ -34,6 +34,7 @@
     "@types/jest": "^23.3.1",
     "@types/node": "^10.7.0",
     "jest": "^23.5.0",
+    "npm-run-all": "^4.1.3",
     "rimraf": "^2.6.2",
     "ts-jest": "^23.1.3",
     "tslint": "^5.11.0",

--- a/packages/tagged/package-lock.json
+++ b/packages/tagged/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@typed-f/tagged",
-	"version": "0.0.1",
+	"version": "0.3.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -186,6 +186,24 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
 			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+			"dev": true
+		},
+		"array-filter": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+			"integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
+			"dev": true
+		},
+		"array-map": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+			"integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
+			"dev": true
+		},
+		"array-reduce": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+			"integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
 			"dev": true
 		},
 		"array-unique": {
@@ -813,6 +831,12 @@
 				"delayed-stream": "~1.0.0"
 			}
 		},
+		"commander": {
+			"version": "2.17.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+			"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+			"dev": true
+		},
 		"compare-versions": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.3.0.tgz",
@@ -1038,6 +1062,12 @@
 				"webidl-conversions": "^4.0.2"
 			}
 		},
+		"duplexer": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+			"dev": true
+		},
 		"ecc-jsbn": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -1133,6 +1163,21 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
 			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
 			"dev": true
+		},
+		"event-stream": {
+			"version": "3.3.4",
+			"resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+			"dev": true,
+			"requires": {
+				"duplexer": "~0.1.1",
+				"from": "~0",
+				"map-stream": "~0.1.0",
+				"pause-stream": "0.0.11",
+				"split": "0.3",
+				"stream-combiner": "~0.0.4",
+				"through": "~2.3.1"
+			}
 		},
 		"exec-sh": {
 			"version": "0.2.2",
@@ -1481,6 +1526,12 @@
 				"map-cache": "^0.2.2"
 			}
 		},
+		"from": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+			"dev": true
+		},
 		"fs-extra": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
@@ -1518,7 +1569,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -1933,7 +1985,8 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -1989,6 +2042,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -2032,12 +2086,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -3117,6 +3173,12 @@
 			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
 			"dev": true
 		},
+		"json-parse-better-errors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"dev": true
+		},
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -3149,6 +3211,12 @@
 			"requires": {
 				"graceful-fs": "^4.1.6"
 			}
+		},
+		"jsonify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+			"dev": true
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -3301,6 +3369,12 @@
 			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
 			"dev": true
 		},
+		"map-stream": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+			"integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+			"dev": true
+		},
 		"map-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -3324,6 +3398,12 @@
 			"requires": {
 				"mimic-fn": "^1.0.0"
 			}
+		},
+		"memorystream": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+			"integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
+			"dev": true
 		},
 		"merge": {
 			"version": "1.2.0",
@@ -3519,6 +3599,12 @@
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
 		},
+		"nice-try": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+			"dev": true
+		},
 		"node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -3556,6 +3642,86 @@
 			"dev": true,
 			"requires": {
 				"remove-trailing-separator": "^1.0.1"
+			}
+		},
+		"npm-run-all": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.3.tgz",
+			"integrity": "sha512-aOG0N3Eo/WW+q6sUIdzcV2COS8VnTZCmdji0VQIAZF3b+a3YWb0AD0vFIyjKec18A7beLGbaQ5jFTNI2bPt9Cg==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^3.2.0",
+				"chalk": "^2.1.0",
+				"cross-spawn": "^6.0.4",
+				"memorystream": "^0.3.1",
+				"minimatch": "^3.0.4",
+				"ps-tree": "^1.1.0",
+				"read-pkg": "^3.0.0",
+				"shell-quote": "^1.6.1",
+				"string.prototype.padend": "^3.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
+					"requires": {
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"load-json-file": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
+					}
+				},
+				"parse-json": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"dev": true,
+					"requires": {
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
+					}
+				},
+				"path-type": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"dev": true,
+					"requires": {
+						"pify": "^3.0.0"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				},
+				"read-pkg": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+					"dev": true,
+					"requires": {
+						"load-json-file": "^4.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^3.0.0"
+					}
+				}
 			}
 		},
 		"npm-run-path": {
@@ -3819,6 +3985,15 @@
 				"pinkie-promise": "^2.0.0"
 			}
 		},
+		"pause-stream": {
+			"version": "0.0.11",
+			"resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+			"dev": true,
+			"requires": {
+				"through": "~2.3"
+			}
+		},
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -3917,6 +4092,15 @@
 			"requires": {
 				"kleur": "^2.0.1",
 				"sisteransi": "^0.1.1"
+			}
+		},
+		"ps-tree": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
+			"integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
+			"dev": true,
+			"requires": {
+				"event-stream": "~3.3.0"
 			}
 		},
 		"pseudomap": {
@@ -4333,6 +4517,18 @@
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
 			"dev": true
 		},
+		"shell-quote": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+			"integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+			"dev": true,
+			"requires": {
+				"array-filter": "~0.0.0",
+				"array-map": "~0.0.0",
+				"array-reduce": "~0.0.0",
+				"jsonify": "~0.0.0"
+			}
+		},
 		"shellwords": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
@@ -4525,6 +4721,15 @@
 			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
 			"dev": true
 		},
+		"split": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+			"integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+			"dev": true,
+			"requires": {
+				"through": "2"
+			}
+		},
 		"split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -4590,6 +4795,15 @@
 			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
 			"dev": true
 		},
+		"stream-combiner": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+			"integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+			"dev": true,
+			"requires": {
+				"duplexer": "~0.1.1"
+			}
+		},
 		"string-length": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -4608,6 +4822,17 @@
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0",
 				"strip-ansi": "^4.0.0"
+			}
+		},
+		"string.prototype.padend": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
+			"integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.4.3",
+				"function-bind": "^1.0.2"
 			}
 		},
 		"string_decoder": {
@@ -4711,6 +4936,12 @@
 			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
 			"dev": true
 		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
+		},
 		"tmpl": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -4796,6 +5027,52 @@
 				"closest-file-data": "^0.1.4",
 				"fs-extra": "6.0.1",
 				"lodash": "^4.17.10"
+			}
+		},
+		"tslib": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+			"dev": true
+		},
+		"tslint": {
+			"version": "5.11.0",
+			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
+			"integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
+			"dev": true,
+			"requires": {
+				"babel-code-frame": "^6.22.0",
+				"builtin-modules": "^1.1.1",
+				"chalk": "^2.3.0",
+				"commander": "^2.12.1",
+				"diff": "^3.2.0",
+				"glob": "^7.1.1",
+				"js-yaml": "^3.7.0",
+				"minimatch": "^3.0.4",
+				"resolve": "^1.3.2",
+				"semver": "^5.3.0",
+				"tslib": "^1.8.0",
+				"tsutils": "^2.27.2"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "1.8.1",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+					"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+					"dev": true,
+					"requires": {
+						"path-parse": "^1.0.5"
+					}
+				}
+			}
+		},
+		"tsutils": {
+			"version": "2.29.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+			"dev": true,
+			"requires": {
+				"tslib": "^1.8.1"
 			}
 		},
 		"tunnel-agent": {

--- a/packages/tagged/package.json
+++ b/packages/tagged/package.json
@@ -22,6 +22,7 @@
     "url": "git+https://github.com/Ailrun/typed-f.git"
   },
   "scripts": {
+    "preversion": "run-s clean build",
     "clean": "rimraf dist",
     "build": "tsc -p ./tsconfig.json",
     "watch": "tsc -w -p ./tsconfig.json",

--- a/packages/tagged/package.json
+++ b/packages/tagged/package.json
@@ -31,6 +31,7 @@
     "@types/jest": "^23.3.1",
     "@types/node": "^10.7.0",
     "jest": "^23.5.0",
+    "npm-run-all": "^4.1.3",
     "rimraf": "^2.6.2",
     "ts-jest": "^23.1.3",
     "tslint": "^5.11.0",


### PR DESCRIPTION
## Description
`lerna publish` is easy to make mistakes, since it does not build packages automatically. In other words, you could mistakenly publish packages without really building them. It makes meaningless version like https://github.com/Ailrun/typed-f/releases/tag/v0.3.3.

This PR add `preversion` hook so that packages are automatically built before published.