### PR TITLE
fix(lens): fix undefined access of focusTo and fromKey

### DIFF
--- a/packages/lens/src/Lens.ts
+++ b/packages/lens/src/Lens.ts
@@ -51,9 +51,17 @@ export class LensS<A, S> extends Lens<A, S> {
     return new LensS(
       (s: S) => this._get(s)[key],
       (s: S) => (n: A[K]) => {
-        const innerRes = copy(this._get(s));
-        innerRes[key] = n;
-        return this._set(s)(innerRes);
+        const part = this._get(s);
+
+        if (part === undefined) {
+          return this._set(s)({
+            [key]: n,
+          } as any);
+        }
+
+        const newPart = copy(part);
+        newPart[key] = n;
+        return this._set(s)(newPart);
       },
     );
   }
@@ -68,6 +76,12 @@ export class LensGenerator<S> {
     return new LensS(
       (s: S) => s[key],
       (s: S) => (b: S[K]) => {
+        if (s === undefined) {
+          return {
+            [key]: b,
+          } as any;
+        }
+
         const res = copy(s);
         res[key] = b;
         return res;


### PR DESCRIPTION
## Description
When you have something like following,
```
interface X {
  key?: {
    inner: number;
  };
}

const x: X = {};
const xLens: LensSProxy<X, X> = new LensGenerator<X>().byProxy();
xLens
  .key
  .inner
  .set()(x)(5);
```
last statement will give you error saying `<xxx> is undefined`. This is because when lens try to set `inner`, lens try to get a current value of `key`, which is `undefined`, and try to set the `5` to its `inner` property.

This is not a best solution (since this can break types if there is more than one properties to the key which is currently `undefined`), just a hot fix for lens problem.